### PR TITLE
Change zint_symbol layout to support Zint v2.6.3

### DIFF
--- a/lib/zint/zint_symbol.rb
+++ b/lib/zint/zint_symbol.rb
@@ -2,6 +2,9 @@ module Zint
   # An FFI wrapper for the Zint C library zint_symbol struct.
   # You should not use this directly, use the Zint::Barcode or
   # its decendents instead.
+  #
+  # For Zint v2.6.3
+  #
   class ZintSymbol < FFI::ManagedStruct
     layout :symbology, :int, 
            :height, :int,
@@ -16,17 +19,23 @@ module Zint
            :option_2, :int,
            :option_3, :int,
            :show_hrt, :int,
+           :fontsize, :int,
            :input_mode, :int,
+           :eci, :int,
            :text, [:uchar, 128],
            :rows, :int,
            :width, :int,
            :primary, [:char, 128],  	
-           :encoded_data , [:uchar, 178*143],
-           :row_height, [:int, 178],
+           :encoded_data , [:uchar, 200*143],
+           :row_height, [:int, 200],
            :errtxt, [:char, 100],
            :bitmap, :pointer,
            :bitmap_width, :int,
-           :bitmap_height, :int
+           :bitmap_height, :int,
+           :bitmap_byte_length, :uchar,
+           :dot_size, :float,
+           :zint_render, :pointer,
+           :debug, :int
   	
   	# release method required for FFI managed structs
   	def self.release ptr


### PR DESCRIPTION
With this change, I'm able to access zint_symbol->bitmap correctly with Zint v2.6.3.